### PR TITLE
Cache gradle dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         java-version: 18
         distribution: temurin
+        cache: 'gradle'
 
     # (Standalone toolchains obsolete)
     # Ubuntu 20.04: r21e, r22, r23b, Custom: r24+


### PR DESCRIPTION
Spotted in
- https://github.com/leotm/react-native-template-new-architecture/pull/565#issuecomment-1113467393

Consider Scala template flavour codegen via CLI opt w caching

---

[`gradle cache not found`](https://github.com/leotm/react-native-template-new-architecture/runs/6231170295?check_suite_focus=true#step:3:30)

[actions/setup-java/blob/main/__tests__/cache.test.ts#L96-L120](https://github.com/actions/setup-java/blob/main/__tests__/cache.test.ts#L96-L120)

All good / expected, no error thrown in either Groovy/Kotlin test cases
- downloads cache based on build.gradle
- downloads cache based on build.gradle.kts
