### PR TITLE
Dedupe yarn.lock post-Renovate pkg/artifact update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":prHourlyLimitNone",
     ":switchToGradleLite"
   ],
+  "postUpdateOptions": ["yarnDedupeHighest"]
   "timezone": "Europe/London",
   "dependencyDashboard": true,
   "packageRules": [


### PR DESCRIPTION
- Run `yarn dedupe --strategy highest` after yarn lockfile updates with Renovate
  - More: https://yarnpkg.com/cli/dedupe#in-depth-explanation
- Fix: https://github.com/leotm/react-native-template-new-architecture/issues/598