### PR TITLE
Update dependency com.android.tools.build:gradle to 7.4.0-alpha02

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ buildscript {
     }
     dependencies {
         // https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
-        classpath("com.android.tools.build:gradle:7.3.0-beta01")
+        classpath('com.android.tools.build:gradle:7.4.0-alpha02')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.1.0")
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Fix: #618

Done manually since not detected by Renovate
Figure/fix later