### PR TITLE
Fix Android release crash on boot

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ buildscript {
     }
     dependencies {
         // https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
-        classpath('com.android.tools.build:gradle:7.4.0-alpha03')
+        classpath('com.android.tools.build:gradle:7.2.1')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.1.0")
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
- Fix: #719
- Downgrade AGP from 7.4.0-alpha03 ❌
- AGP 7.2.0 ✅  https://github.com/facebook/react-native/pull/33817
- AGP 7.4.0-beta03 ❌
- AGP 7.2.1 ✅

---

#### Flipper

```console
FATAL EXCEPTION: create_react_context

java.lang.RuntimeException: Unable to load script. Make sure you're either running Metro (run 'npx react-native start') or that your bundle 'index.android.bundle' is packaged correctly for release.

FATAL EXCEPTION: create_react_context
Process: com.leotm.myapp, PID: 13832
java.lang.RuntimeException: Unable to load script. Make sure you're either running Metro (run 'npx react-native start') or that your bundle 'index.android.bundle' is packaged correctly for release.
	at com.facebook.react.bridge.CatalystInstanceImpl.jniLoadScriptFromAssets(Native Method)
	at com.facebook.react.bridge.CatalystInstanceImpl.loadScriptFromAssets(CatalystInstanceImpl.java:248)
	at com.facebook.react.bridge.JSBundleLoader$1.loadScript(JSBundleLoader.java:29)
	at com.facebook.react.bridge.CatalystInstanceImpl.runJSBundle(CatalystInstanceImpl.java:277)
	at com.facebook.react.ReactInstanceManager.createReactContext(ReactInstanceManager.java:1404)
	at com.facebook.react.ReactInstanceManager.access$1200(ReactInstanceManager.java:136)
	at com.facebook.react.ReactInstanceManager$5.run(ReactInstanceManager.java:1108)
	at java.lang.Thread.run(Thread.java:920)
```