### PR TITLE
Patch React Native 0.70.0-rc.0 to bake prod env var for iOS Release

### DIFF
--- a/.yarn/patches/react-native-npm-0.70.0-rc.0-00aa7e4469.patch
+++ b/.yarn/patches/react-native-npm-0.70.0-rc.0-00aa7e4469.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/react_native_pods.rb b/scripts/react_native_pods.rb
+index 3d86c4f3de4e3db91dee20085545aacacecebf5b..28abb4df3c5e0028d341201cae87dae1b966ad43 100644
+--- a/scripts/react_native_pods.rb
++++ b/scripts/react_native_pods.rb
+@@ -34,7 +34,7 @@ def use_react_native! (options={})
+   new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+ 
+   # Include DevSupport dependency
+-  production = options[:production] ||= false
++  production = ENV['PRODUCTION'] == '1'
+ 
+   # Include Hermes dependencies
+   hermes_enabled = options[:hermes_enabled] != nil ? options[:hermes_enabled] : true

--- a/package.json
+++ b/package.json
@@ -143,5 +143,8 @@
       "prettier --write"
     ]
   },
-  "packageManager": "yarn@3.2.2"
+  "packageManager": "yarn@3.2.2",
+  "resolutions": {
+    "react-native@0.70.0-rc.0": "patch:react-native@npm:0.70.0-rc.0#.yarn/patches/react-native-npm-0.70.0-rc.0-00aa7e4469.patch"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17502,6 +17502,50 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-native@patch:react-native@npm:0.70.0-rc.0#.yarn/patches/react-native-npm-0.70.0-rc.0-00aa7e4469.patch::locator=myapp%40workspace%3A.":
+  version: 0.70.0-rc.0
+  resolution: "react-native@patch:react-native@npm%3A0.70.0-rc.0#.yarn/patches/react-native-npm-0.70.0-rc.0-00aa7e4469.patch::version=0.70.0-rc.0&hash=32b74d&locator=myapp%40workspace%3A."
+  dependencies:
+    "@jest/create-cache-key-function": ^27.0.1
+    "@react-native-community/cli": ^9.0.0-alpha.3
+    "@react-native-community/cli-platform-android": ^9.0.0-alpha.3
+    "@react-native-community/cli-platform-ios": ^9.0.0-alpha.3
+    "@react-native/assets": 1.0.0
+    "@react-native/normalize-color": 2.0.0
+    "@react-native/polyfills": 2.0.0
+    abort-controller: ^3.0.0
+    anser: ^1.4.9
+    base64-js: ^1.1.2
+    event-target-shim: ^5.0.1
+    invariant: ^2.2.4
+    jsc-android: ^250230.2.1
+    memoize-one: ^5.0.0
+    metro-react-native-babel-transformer: 0.71.3
+    metro-runtime: 0.71.3
+    metro-source-map: 0.71.3
+    mkdirp: ^0.5.1
+    nullthrows: ^1.1.1
+    pretty-format: ^26.5.2
+    promise: ^8.0.3
+    react-devtools-core: 4.24.0
+    react-native-codegen: ^0.70.3
+    react-native-gradle-plugin: ^0.70.0
+    react-refresh: ^0.4.0
+    react-shallow-renderer: ^16.15.0
+    regenerator-runtime: ^0.13.2
+    scheduler: ^0.22.0
+    stacktrace-parser: ^0.1.3
+    use-sync-external-store: ^1.0.0
+    whatwg-fetch: ^3.0.0
+    ws: ^6.1.4
+  peerDependencies:
+    react: 18.1.0
+  bin:
+    react-native: cli.js
+  checksum: d93d3d4ff757f134f149cfed922058928639a08fea5dba8deaec2f30738295b89034755fc24cf1e5aca1cee9640fce10a58c0b2cac05d737cb875cab5e4b7955
+  languageName: node
+  linkType: hard
+
 "react-popper-tooltip@npm:^2.8.3":
   version: 2.11.1
   resolution: "react-popper-tooltip@npm:2.11.1"


### PR DESCRIPTION
Similar to: https://github.com/facebook/react-native/pull/34234

Fix: #794