### PR TITLE
Add plist `MARKETING_VERSION` to pbxproj

### DIFF
--- a/ios/MyApp.xcodeproj/project.pbxproj
+++ b/ios/MyApp.xcodeproj/project.pbxproj
@@ -514,6 +514,7 @@
 					"$(inherited)",
 					"-DFB_SONARKIT_ENABLED=1",
 				);
+				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -541,6 +542,7 @@
 					"$(inherited)",
 					"-DFB_SONARKIT_ENABLED=1",
 				);
+				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
Fix: https://github.com/leotm/react-native-template-new-architecture/issues/1449

Fix: https://github.com/leotm/react-native-template-new-architecture/issues/1450

Missed during upg, ref:
- https://react-native-community.github.io/upgrade-helper/?from=0.70.6&to=0.71.0