### PR TITLE
Upgrade TypeScript 5 Beta to 5 Stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-test-renderer": "18.2.0",
     "reactotron-react-native": "5.0.3",
     "ts-node": "10.9.1",
-    "typescript": "beta",
+    "typescript": "5.0.3",
     "webpack": "5.77.0",
     "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.13.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16140,7 +16140,7 @@ __metadata:
     react-test-renderer: "npm:18.2.0"
     reactotron-react-native: "npm:5.0.3"
     ts-node: "npm:10.9.1"
-    typescript: "npm:beta"
+    typescript: "npm:5.0.3"
     webpack: "npm:5.77.0"
     webpack-cli: "npm:5.0.1"
     webpack-dev-server: "npm:4.13.2"
@@ -21132,23 +21132,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:beta":
-  version: 5.0.0-beta
-  resolution: "typescript@npm:5.0.0-beta"
+"typescript@npm:5.0.3":
+  version: 5.0.3
+  resolution: "typescript@npm:5.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 036c77994118855f806df5e346f9afc57dfc4044fd97d6aba23fd015633fff84790554748d65982a75a294e395b267e28f1fa9ec4bc5d576436ebe1de91f1b1f
+  checksum: 45ee631503499861d77d7a7b1d49fb5c62ae6bb5a99cdf5110f3e21c627397f5f76cf3d67ee0b223a33cfad469ea18de7650cab7a529b1376f5218a27b81671e
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3Abeta#optional!builtin<compat/typescript>":
-  version: 5.0.0-beta
-  resolution: "typescript@patch:typescript@npm%3A5.0.0-beta#optional!builtin<compat/typescript>::version=5.0.0-beta&hash=8b0de9"
+"typescript@patch:typescript@npm%3A5.0.3#optional!builtin<compat/typescript>":
+  version: 5.0.3
+  resolution: "typescript@patch:typescript@npm%3A5.0.3#optional!builtin<compat/typescript>::version=5.0.3&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 36ba51f0f85f701762f996c1cc08fb3eb3a4c2cc9488feeb0ffa175be461bf34c62f2b43e1d3d4a414b52ed412e21434c11c5f53bd0a797fedb256716ca68755
+  checksum: 66967b1418927f8c780bcec443e6e1572d0c88314e3b45797d22bffc8981b3c8e687a37f24bcad00e2d349722df225e758678559e810a6673f4773b8f44eb5d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Close: https://github.com/leotm/react-native-template-new-architecture/issues/1649